### PR TITLE
[heckbug] fix bad require causing Lita to fail at runtime; v0.1.2

### DIFF
--- a/lib/lita-lbcfg/version.rb
+++ b/lib/lita-lbcfg/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module LitaLBCfg
-  VERSION ||= '0.1.1'.freeze
+  VERSION ||= '0.1.2'.freeze
 end

--- a/lib/lita/handlers/lbcfg.rb
+++ b/lib/lita/handlers/lbcfg.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'dd_spacecadet/error'
+require 'dd_spacecadet'
 require 'lita-lbcfg/loader'
 
 module Lita

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 require 'lita-lbcfg'
-require 'dd_spacecadet'
 require 'lita/rspec'
 
 # A compatibility mode is provided for older plugins upgrading from Lita 3. Since this plugin


### PR DESCRIPTION
I made the mistake of including `dd_spacecadet` within the `spec_helper.rb` file, which caused us to not catch an improper `require` in testing. This removes the require from the `spec_helper.rb` and fixes the `require` statement in the Lita handler.

This should resolve the outstanding issues.
